### PR TITLE
These modifications should solve the Java version trouble (issue #10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 /upla-unimozer.ini
 /trans.txt
 /upload
+/bin/

--- a/upla.ini
+++ b/upla.ini
@@ -3,6 +3,7 @@ program=Structorizer.jar
 programUri=https://structorizer.fisch.lu/webstart/Structorizer.jar
 md5Uri=https://structorizer.fisch.lu/webstart/md5.php
 iconName=structorizer.png
+minJavaVersion=11.0.0
 
-#last updated Sat Jun 22 08:52:30 CEST 2019
+#last updated Mon Oct 30 01:38:30 CEST 2023
 #Sat Jun 22 08:52:30 CEST 2019


### PR DESCRIPTION
Tested in a heterogenous environment (AdoptOpenJDK 11.0.6 + jre1.8.0_391), also checks new optional `minJavaVersion` property in upla.ini.
Addresses #10 (and https://github.com/fesch/Structorizer.Desktop/issues/1100)
Should be delivered together with Structorizer 3.32-13, which is just being finished.