### PR TITLE
Merge defects amended.

### DIFF
--- a/src/lu/fisch/upla/Main.java
+++ b/src/lu/fisch/upla/Main.java
@@ -71,8 +71,8 @@ public class Main {
         }
         
         if((System.getProperty("os.name").toLowerCase().startsWith("mac os x") ||
-            System.getProperty("os.name").toLowerCase().startsWith("nix") ||
-            System.getProperty("os.name").toLowerCase().startsWith("nux")) &&
+            System.getProperty("os.name").toLowerCase().endsWith("nix") ||
+            System.getProperty("os.name").toLowerCase().endsWith("nux")) &&
             !path.startsWith("/"))
         {
             path = "/"+path;
@@ -216,6 +216,8 @@ public class Main {
             JOptionPane.showMessageDialog(null, e.getMessage(), "Error #main 2", JOptionPane.ERROR_MESSAGE);
             System.exit(1);
         }
+        // make sure we terminate the process
+        System.exit(0);
     }
     
     private static boolean isOnline()


### PR DESCRIPTION
You overlooked two of your own changes that got lost on merging my code modifications. Apparently GitHub had failed correctly to track your last commit, such that the differences weren't shown in detail but as complete content blocks.
In fact I had already wondered why an OS name should start with "nix" or "nux" but didn't dare to change it and then forgot to discuss the issue. This will not of course affect Windows installations - but the use in Unix and Linux environments.

Also you inserted a `System.exit(0);` instruction at the end of `Main.main()` though I doubt its necessity: what else should happen when a main function gets to its end and thus returns? The OS can hardly hold the process in an eternal limbo. So it will of course terminate the process and - since not stated otherwise - assume it to have been successful (and thus conjure up result value 0). In fact, however, if function `main` should really get there then it cannot have been successful because `start()` only returns if no Java executable was found (which is unlikely, given the fact that a Java process is just running). Hence, an exit code other than 0 would have been more appropriate here. (A none-zero exit code should be the only justification for `System.exit()` at the very end of the main algorithm.)

I restored both of your changes notwithstanding the above discussion. So you should decide after the formal merge.